### PR TITLE
[ENH] Extend time until stale to 75 days

### DIFF
--- a/template_workflows/stale.yml
+++ b/template_workflows/stale.yml
@@ -22,4 +22,3 @@ jobs:
           days-before-close: -1
           stale-issue-label: '_flag:stale'
           exempt-issue-labels: 'Roadmap,Milestone,Epic,someday'
-          labels-to-remove-when-unstale: '_flag:stale'

--- a/template_workflows/stale.yml
+++ b/template_workflows/stale.yml
@@ -18,7 +18,8 @@ jobs:
             - archive: sometimes an issue has important information or ideas but we won't work on it soon. In this case
             apply the `someday` label to show that this won't be prioritized. The stalebot will ignore issues with this
             label in the future. Use sparingly!
-          days-before-stale: 30
+          days-before-stale: 75
           days-before-close: -1
           stale-issue-label: '_flag:stale'
           exempt-issue-labels: 'Roadmap,Milestone,Epic,someday'
+          labels-to-remove-when-unstale: '_flag:stale'


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include the [WIP] tag in its title, or create a draft PR. -->


<!---
Below is a suggested pull request template.
It's designed to capture info we've found to be useful in reviewing pull requests, but feel free to add more details you feel are relevant/necessary.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- only mark issues as stale after 75 days
- ensure that the `_flag:stale` label is removed when the issue becomes unstale

<!-- To be checked off by reviewers -->
## Checklist

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see https://neurobagel.org/contributing/pull_requests for more info)_
- [ ] PR links to GitHub issue with mention `Closes #XXXX`
- [ ] Tests pass
- [ ] Checks pass

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.
