### PR TITLE
[FIX] Lift substitution of GH variables to sync.yml template to be propagated

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -42,18 +42,27 @@ neurobagel/api:
     dest: .github/workflows/build_docker_on_release.yml
     template:
       synced_repo:
+        dockerhub_username: '${{ secrets.DOCKERHUB_USERNAME }}'
+        dockerhub_token: '${{ secrets.DOCKERHUB_TOKEN }}'
         docker_repo_name: 'api'
+        release_tag: '${{ github.event.release.tag_name }}'
 
 neurobagel/bagel-cli:
   - source: template_workflows/auto_release/build_docker_on_release.yml
     dest: .github/workflows/build_docker_on_release.yml
     template:
       synced_repo:
+        dockerhub_username: '${{ secrets.DOCKERHUB_USERNAME }}'
+        dockerhub_token: '${{ secrets.DOCKERHUB_TOKEN }}'
         docker_repo_name: 'bagelcli'
+        release_tag: '${{ github.event.release.tag_name }}'
 
 neurobagel/federation-api:
   - source: template_workflows/auto_release/build_docker_on_release.yml
     dest: .github/workflows/build_docker_on_release.yml
     template:
       synced_repo:
+        dockerhub_username: '${{ secrets.DOCKERHUB_USERNAME }}'
+        dockerhub_token: '${{ secrets.DOCKERHUB_TOKEN }}'
         docker_repo_name: 'federation_api'
+        release_tag: '${{ github.event.release.tag_name }}'

--- a/template_workflows/auto_release/build_docker_on_release.yml
+++ b/template_workflows/auto_release/build_docker_on_release.yml
@@ -15,8 +15,8 @@ jobs:
         name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: {{ synced_repo.dockerhub_username }}
+          password: {{ synced_repo.dockerhub_token }}
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -27,4 +27,4 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/{{ synced_repo.docker_repo_name }}:latest, ${{ secrets.DOCKERHUB_USERNAME }}/{{ synced_repo.docker_repo_name }}:${{ github.event.release.tag_name }}
+          tags: {{ synced_repo.dockerhub_username }}/{{ synced_repo.docker_repo_name }}:latest, {{ synced_repo.dockerhub_username }}/{{ synced_repo.docker_repo_name }}:{{ synced_repo.release_tag }}


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the PR process for Neurobagel repositories, see https://neurobagel.org/contributing/pull_requests/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- Use of templates in repo-file-sync action doesn't play nicely with GH variable substitution present in the same workflow files, as this leads to conflicts in use of `{{ }}` for variable expansion
  - see https://github.com/neurobagel/bagel-cli/pull/271/files#diff-10b217627ccf6e5163f99ce9623fb2f56a3d3b4b1de4d022c864824f2d95e6ba for example
- To try and remedy this, this PR makes the GH variable substitution part of the template as well so the correct syntax is propagated to wf files

<!-- To be checked off by reviewers -->
## Checklist

- [ ] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see https://neurobagel.org/contributing/pull_requests for more info)_
- [ ] PR links to GitHub issue with mention `Closes #XXXX`
- [ ] Tests pass
- [ ] Checks pass

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.
