### PR TITLE
[FIX] Try different skip keywords in commit msg

### DIFF
--- a/template_configs/.autorc
+++ b/template_configs/.autorc
@@ -4,6 +4,9 @@
     "baseBranch": "main",
     "author": "Chef Bot <chef@neurobagel.org>",
     "noVersionPrefix": false,
+    "changelog": {
+        "message": "Update CHANGELOG.md [skip pre-commit.ci] [skip ci]"
+    },
     "plugins": [
         "git-tag",
         "released",


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the Neurobagel PR process and other contributing guidelines, see https://neurobagel.org/contributing/CONTRIBUTING/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #87 

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- Try a different keyword `[skip pre-commit.ci]` to skip pre-commit-ci on changelog commits, as per https://pre-commit.ci/#features
  - I realized that technically `[skip ci]` (which is there by default) should already do the trick? So not sure if the fact that it (sometimes?) doesn't work is a pre-commit-ci bug or due to some other problem w/ how we've set up auto-releases

<!-- To be checked off by reviewers -->
## Checklist
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING#pull-request-guidelines) for more info)_
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [ ] Tests pass
- [x] Checks pass

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.
